### PR TITLE
refactor(docker-compose.yaml): add persistent volume (postgresql, rabbitmq)

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,25 +3,27 @@ version: "3.8"
 services:
   db:
     image: postgres:latest
-    environment:
-      POSTGRES_USER: nft
-      POSTGRES_PASSWORD: nft
-      POSTGRES_DB: nft
     ports:
       - '5434:5432'
     volumes:
       - ./init.sql:/docker-entrypoint-initdb.d/init.sql
+      - ${HOME}/Google Drive/내 드라이브/marketplace/db:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: nft
+      POSTGRES_PASSWORD: nft
+      POSTGRES_DB: nft
+      PGDATA: /var/lib/postgresql/data/pgdata      
 
   rabbitmq:
     image: rabbitmq:3-management
-    environment:
-      RABBITMQ_DEFAULT_USER: closeSea
-      RABBITMQ_DEFAULT_PASS: closeSeaP@ssword
     ports:
       - '5672:5672'
       - '15672:15672'
     volumes:
-      - ./rabbitmq_data:/var/lib/rabbitmq
+      - ${HOME}/Google Drive/내 드라이브/marketplace/rabbitmq:/var/lib/rabbitmq
+    environment:
+      RABBITMQ_DEFAULT_USER: closeSea
+      RABBITMQ_DEFAULT_PASS: closeSeaP@ssword
 
   redis-node-0:
     image: docker.io/bitnami/redis-cluster:7.2


### PR DESCRIPTION
구글 드라이브만 하시고 파일 동기화만 다 되면
아래 docker-compose.yaml 통해서 동일한 데이터 사용하실 수 있습니다.